### PR TITLE
feat: add back data deletion page

### DIFF
--- a/src/components/footer/Footer.vue
+++ b/src/components/footer/Footer.vue
@@ -30,6 +30,7 @@
             >
             <router-link to="/legal/privacy" target="_self">Privacy Policy</router-link>
             <router-link to="/legal/terms" target="_self">Terms & Conditions</router-link>
+            <router-link to="/legal/data-deletion" target="_self">Data Deletion</router-link>
             <router-link to="/help" target="_self">Help</router-link>
         </div>
     </footer>

--- a/src/router.ts
+++ b/src/router.ts
@@ -17,6 +17,11 @@ export const routes: RouteRecordRaw[] = [
         component: () => import('./views/legal/Privacy.vue'),
     },
     {
+        path: '/legal/data-deletion',
+        name: 'data-deletion',
+        component: () => import('./views/legal/DataDeletion.vue'),
+    },
+    {
         path: '/help',
         name: 'help',
         component: () => import('./views/Help.vue'),

--- a/src/views/legal/DataDeletion.vue
+++ b/src/views/legal/DataDeletion.vue
@@ -1,0 +1,25 @@
+<template>
+    <article class="page markdown-body">
+        <p>
+            <strong>Last updated</strong><br />
+            March 16th 2024
+        </p>
+        <h1><strong>Data Deletion</strong></h1>
+        <p>
+            There are two ways to delete permanently **all** your data from our servers:
+        </p>
+        <h2>Method 1 (instantaneous)</h2>
+        <p>
+            Open the Dumpus app, go to your settings and press the <strong>"Quit and reset"</strong>
+            button. All your packages will be deleted from our servers.
+        </p>
+        <h2>Method 2 (can take a few days)</h2>
+        <p>
+            Send us an email at <code>contact@dumpus.app</code> with your Package ID. You can get it by
+            clicking the card <strong>"Package ID"</strong> under the <strong>"Package details"</strong>
+            section in the settings. Do not include any other information (such as your Discord Data Package).
+        </p>
+    </article>
+</template>
+
+<style src="@/assets/css/legal/legal.css"></style>


### PR DESCRIPTION
See https://github.com/dumpus-app/dumpus-app/commit/d6399e515c5073c1b6db46e4eef6c64cb4d03257. This means we need to update the Data safety form with the new url