### PR TITLE
chore: add deploy.sh for S3 + CloudFront

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Deploy dumpus-landing to AWS (S3 + CloudFront).
+# Requires: pnpm, awscli v2, AWS creds with access to the dumpus-app prod account.
+
+set -euo pipefail
+
+BUCKET="dumpus-app-landing"
+DISTRIBUTION_ID="E3QLCNIH63M129"
+
+pnpm install --frozen-lockfile
+pnpm run build
+
+aws s3 sync dist/ "s3://${BUCKET}/" \
+    --delete \
+    --cache-control "public, max-age=3600"
+
+aws cloudfront create-invalidation \
+    --distribution-id "${DISTRIBUTION_ID}" \
+    --paths '/*' \
+    --query 'Invalidation.{Id:Id,Status:Status}'
+
+echo "Deployed. Live at https://dumpus.app"


### PR DESCRIPTION
## Summary
- Adds `deploy.sh`: builds the Vite site and syncs to S3 + invalidates CloudFront
- Site is now hosted on `s3://dumpus-app-landing` behind CloudFront `E3QLCNIH63M129` (apex `dumpus.app`)
- Replaces the now-defunct CapRover/Dockerfile flow (PulseHeberg VPS expired)

## Test plan
- [x] `bash deploy.sh` from a clean checkout with valid AWS creds
- [x] Verify https://dumpus.app/ returns 200
- [x] Verify https://dumpus.app/help, /legal/privacy etc. return 200 (CloudFront Function rewrites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)